### PR TITLE
Fix duplicate detection in Yandex Music

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -123,7 +123,7 @@ class YandexMusic(MusicService):
             track_key = (full_track.title.lower(), full_track.artists[0].name.lower())
 
             if track_key in tracks_seen:
-                tracks_to_remove.append(track.track_id)
+                tracks_to_remove.append(track.id)
             else:
                 tracks_seen.add(track_key)
 


### PR DESCRIPTION
## Summary
- use track.id when collecting duplicate tracks

## Testing
- `pytest -q`
- manual script simulating duplicate tracks

------
https://chatgpt.com/codex/tasks/task_e_68a0d643d2388331a214ee31711d9147